### PR TITLE
Bug fix for using CanvasKit on web pages.

### DIFF
--- a/lib/platform/canvas_kit.dart
+++ b/lib/platform/canvas_kit.dart
@@ -1,0 +1,2 @@
+// https://stackoverflow.com/questions/63207658/how-to-detect-flutter-web-canvaskit-or-html-renderer
+export 'canvas_kit_stub.dart' if (dart.library.html) 'canvas_kit_web.dart';

--- a/lib/platform/canvas_kit_stub.dart
+++ b/lib/platform/canvas_kit_stub.dart
@@ -1,0 +1,4 @@
+/// Whether the CanvasKit renderer is being used on web.
+///
+/// Always returns `false` on non-web.
+bool get isCanvasKit => false;

--- a/lib/platform/canvas_kit_web.dart
+++ b/lib/platform/canvas_kit_web.dart
@@ -1,0 +1,6 @@
+import 'dart:js';
+
+/// Whether the CanvasKit renderer is being used on web.
+///
+/// Always returns `false` on non-web.
+bool get isCanvasKit => context['flutterCanvasKit'] != null;

--- a/lib/platform/web_svg.dart
+++ b/lib/platform/web_svg.dart
@@ -1,4 +1,6 @@
+import 'package:flag/platform/canvas_kit.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 import 'interface_svg.dart' as Interface;
 
@@ -33,17 +35,34 @@ class PlatformSvg extends Interface.PlatformSvg {
 
   @override
   Widget build(BuildContext context) {
-    return Image.network(
-      "assets/$assetName",
-      width: width,
-      height: height,
-      semanticLabel: semanticLabel,
-      fit: fit,
-    );
+    return isCanvasKit
+        ? Container(
+            width: width,
+            height: height,
+            child: SvgPicture.asset(
+              assetName,
+              semanticsLabel: semanticLabel,
+              fit: fit,
+            ),
+          )
+        : Image.network(
+            "assets/$assetName",
+            width: width,
+            height: height,
+            semanticLabel: semanticLabel,
+            fit: fit,
+          );
   }
 
   static Future<void> preloadFlag(
       BuildContext context, String assetName) async {
-    await precacheImage(NetworkImage("assets/$assetName"), context);
+    isCanvasKit
+        ? await precachePicture(
+            ExactAssetPicture(
+              SvgPicture.svgStringDecoder,
+              assetName,
+            ),
+            context)
+        : await precacheImage(NetworkImage("assets/$assetName"), context);
   }
 }


### PR DESCRIPTION
The flags are not displayed if Flutter uses "CanvasKit" in web mode. There are two renderers that can be used in web mode:

https://flutter.dev/docs/development/tools/web-renderers

Image.network works only in "html" mode to display an SVG file. In "CanvasKit" mode SVG files have to be displayed in the same way as on Android and iOS.

To check if "CanvasKit" is used the solution that is described here was used:

https://stackoverflow.com/questions/63207658/how-to-detect-flutter-web-canvaskit-or-html-renderer

With these changes the flags are now correctly displayed in "CanvasKit" web mode.

Thank you very much for creating this project! I hope my contribution will be useful! :-)